### PR TITLE
Use <Pump> and <Toolbar>

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,51 +1,60 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import type { ReactNode } from "react";
 import { baseOptions } from "@/app/layout.config";
-import { basehub } from "basehub";
+import { Pump } from "basehub/react-pump";
 import { PageTree } from "fumadocs-core/server";
-import { draftMode } from "next/headers";
 
 export default async function Layout({ children }: { children: ReactNode }) {
-  const { documentation } = await basehub({
-    draft: (await draftMode()).isEnabled,
-  }).query({
-    documentation: { items: { slug: true, _title: true, category: true } },
-  });
-
-  const items: PageTree.Node[] = [];
-
-  for (const item of documentation.items) {
-    let idx = items.length;
-
-    if (item.category && item.category !== "Root") {
-      idx = items.findIndex((parent) => parent.name === item.category);
-
-      if (idx === -1) {
-        items.push({
-          type: "separator",
-          name: item.category,
-        });
-
-        idx = items.length;
-      }
-    }
-
-    items.splice(idx, 0, {
-      type: "page",
-      name: item._title,
-      url: item.slug ? `/docs/${item.slug}` : "/docs",
-    });
-  }
-
   return (
-    <DocsLayout
-      tree={{
-        name: "Docs",
-        children: items,
-      }}
-      {...baseOptions}
+    <Pump
+      queries={[
+        {
+          documentation: {
+            items: { slug: true, _title: true, category: true },
+          },
+        },
+      ]}
     >
-      {children}
-    </DocsLayout>
+      {async ([{ documentation }]) => {
+        "use server";
+
+        const items: PageTree.Node[] = [];
+
+        for (const item of documentation.items) {
+          let idx = items.length;
+
+          if (item.category && item.category !== "Root") {
+            idx = items.findIndex((parent) => parent.name === item.category);
+
+            if (idx === -1) {
+              items.push({
+                type: "separator",
+                name: item.category,
+              });
+
+              idx = items.length;
+            }
+          }
+
+          items.splice(idx, 0, {
+            type: "page",
+            name: item._title,
+            url: item.slug ? `/docs/${item.slug}` : "/docs",
+          });
+        }
+
+        return (
+          <DocsLayout
+            tree={{
+              name: "Docs",
+              children: items,
+            }}
+            {...baseOptions}
+          >
+            {children}
+          </DocsLayout>
+        );
+      }}
+    </Pump>
   );
 }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,42 +1,50 @@
-import { basehub } from "basehub";
+import { Pump } from "basehub/react-pump";
 import { RichText } from "basehub/react-rich-text";
 import { Card, Cards } from "fumadocs-ui/components/card";
 import { DocsBody, DocsPage, DocsTitle } from "fumadocs-ui/page";
-import { draftMode } from "next/headers";
 
 export default async function Page() {
-  const { documentation } = await basehub({
-    draft: (await draftMode()).isEnabled,
-  }).query({
-    documentation: {
-      items: {
-        _slug: true,
-        _title: true,
-        richText: {
-          json: {
-            content: true,
+  return (
+    <Pump
+      queries={[
+        {
+          documentation: {
+            items: {
+              _slug: true,
+              _title: true,
+              richText: {
+                json: {
+                  content: true,
+                },
+              },
+            },
           },
         },
-      },
-    },
-  });
-  const [home, ...items] = documentation.items;
+      ]}
+    >
+      {async ([{ documentation }]) => {
+        "use server";
 
-  return (
-    <DocsPage>
-      <DocsTitle>Introduction</DocsTitle>
-      <DocsBody className="text-sm">
-        <RichText content={home.richText?.json.content} />
-        <Cards>
-          {items.map((item) => (
-            <Card
-              key={item._slug}
-              href={`/docs/${item._slug}`}
-              title={item._title}
-            />
-          ))}
-        </Cards>
-      </DocsBody>
-    </DocsPage>
+        const [home, ...items] = documentation.items;
+
+        return (
+          <DocsPage>
+            <DocsTitle>Introduction</DocsTitle>
+            <DocsBody className="text-sm">
+              <RichText content={home.richText?.json.content} />
+              <Cards>
+                {items.map((item) => (
+                  <Card
+                    key={item._slug}
+                    href={`/docs/${item._slug}`}
+                    title={item._title}
+                  />
+                ))}
+              </Cards>
+            </DocsBody>
+          </DocsPage>
+        );
+      }}
+    </Pump>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist_Mono } from "next/font/google";
 import type { ReactNode } from "react";
 import { basehub } from "basehub";
 import { Provider } from "./provider";
+import { Toolbar } from "basehub/next-toolbar";
 
 const inter = Geist_Mono({
   subsets: ["latin"],
@@ -18,6 +19,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
         <Provider _searchKey={documentation._searchKey}>{children}</Provider>
+        <Toolbar />
       </body>
     </html>
   );


### PR DESCRIPTION
This PR migrates some of the `basehub().query()` uses to `<Pump>`. Pump gives us real time preview, as well as automatic draftMode detection—it's pretty cool!

I've also mounted `<Toolbar />` in layout to make sure [automatic on-demand revalidation](https://basehub.com/blog/automatic-on-demand-revalidation-for-nextjs-how-it-works) works as expected.